### PR TITLE
updated 'vscale_core.v' with missing include statement

### DIFF
--- a/src/main/verilog/vscale_core.v
+++ b/src/main/verilog/vscale_core.v
@@ -1,4 +1,5 @@
 `include "vscale_hasti_constants.vh"
+`include "vscale_ctrl_constants.vh"
 `include "vscale_csr_addr_map.vh"
 
 module vscale_core(


### PR DESCRIPTION
I'm using the VScale core to prototype some ideas in functional verification. I needed to make a small modification to get it running in IUS. This should work fine in your tool (VCS) as well.