### PR TITLE
Added else-statement to remove latch-inference on wdata_internal

### DIFF
--- a/src/main/verilog/vscale_csr_file.v
+++ b/src/main/verilog/vscale_csr_file.v
@@ -113,6 +113,9 @@ module vscale_csr_file(
            default : wdata_internal = wdata;
          endcase // case (cmd)
       end
+      else begin
+        wdata_internal = wdata;
+      end
    end // always @ begin
 
    assign uinterrupt = 1'b0;


### PR DESCRIPTION
Hi,

I'm trying to use vscale for a project on the Xilinx Arty board and discovered that latches were inferred on wdata_internal. Will try to help out resolving the combinatorial loop later on... 